### PR TITLE
Remove quotes from "song" key

### DIFF
--- a/docs/installation/initialization.md
+++ b/docs/installation/initialization.md
@@ -41,7 +41,7 @@ To configure Amplitude.js, you need to call the init function on the Amplitude o
 
 ```javascript
 	Amplitude.init({
-		"songs": [
+		songs: [
 			{
 				"name": "Song Name 1",
 				"artist": "Artist Name",


### PR DESCRIPTION
Subject for discussion:

This example of a playlist is given again in other sections of the documentation, e.g. in "Playlists" (under "Configuration") or "Debug", where the key "song" is used without quotes, it would make sense to make the writing consistent.

This would also mean to apply this change to examples in other places. I would happily add those other places, if this change is accepted and finds the support of the creators of AmplitudeJS.